### PR TITLE
Fix cart input quantity margin

### DIFF
--- a/public/css/app/components/_cart.scss
+++ b/public/css/app/components/_cart.scss
@@ -299,6 +299,7 @@
 input[type="number"].wps-cart-item__quantity {
   color: black;
   margin-top: 0;
+  margin-right: 0;
   height: auto;
   font-size: 18px;
   border: none;


### PR DESCRIPTION
The `.wps-cart-item__quantity` margin is applied to the `<span>` and the `<input>`, which has an ugly effect if the input background isn't white (see screenshot). This fixes that :)

![image](https://user-images.githubusercontent.com/1671933/52192190-835fdc80-2816-11e9-858b-646b8931c594.png)
